### PR TITLE
Fixed AccessDenied error

### DIFF
--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -35,7 +35,7 @@ class Client implements ClientInterface
             $this->ruleset = $ruleset;
         }
 
-        $this->imagePathPNG = $this->imagePathPNG . '/' . $this->emojiVersion . '/png/' . $this->emojiSize . '/';
+        $this->imagePathPNG = $this->imagePathPNG . '/' . $this->emojiVersion . '/png/unicode/' . $this->emojiSize . '/';
         $this->spriteSize = ($this->spriteSize == '32' || $this->spriteSize == '64') ? $this->spriteSize : '32';
     }
 


### PR DESCRIPTION
Fixed AccessDenied error due to missing url parameter (see https://github.com/joypixels/emoji-toolkit/issues/22)