### PR TITLE
Upgrade maintenance script to s9e/regexp-builder:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "ext-intl": "*",
         "phpunit/phpunit": "~4.6 || ~5.0",
-        "s9e/regexp-builder": "^1.4"
+        "s9e/regexp-builder": "^2.0"
     },
     "scripts": {
         "generate-regex": "php lib/php/utils/generateRegex.php"

--- a/lib/php/utils/generateRegex.php
+++ b/lib/php/utils/generateRegex.php
@@ -31,10 +31,14 @@ foreach ($ranges as [$min, $max])
 	}
 }
 
-$builder = new s9e\RegexpBuilder\Builder([
-	'input'  => 'Utf8',
-	'output' => 'PHP'
-]);
+// The delimiter and modifiers should match what's used in toShort()
+$builder = s9e\RegexpBuilder\Factory\PHP::getBuilder(
+	delimiter: '/',
+	modifiers: 'ui'
+);
+// The regexp is used as part of another. Marking it as not "standalone" will cause it to
+// be wrapped in a non-capturing group so it doesn't interfere with other alternations
+$builder->standalone = false;
 $regexp = $builder->build($matches);
 
 patchFile(


### PR DESCRIPTION
This small PR bumps the requirement to s9e/regexp-builder:^2.0

There is no functional difference between the 1.4 and 2.0 versions as far as this project is concerned. In fact, at the time of this PR the `generateRegex.php` script produces the same output with either version. The difference is that new development happens on the 2.0 branch whereas 1.4 will only receive critical bug fixes.

In this version, [factories](https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)) have been created for each supported regexp engine. Instead of configuring a `Builder` manually, you'll only have to specify which regexp engine/programming language this is for (in this case, `PHP`), and what the regexp's delimiter and modifiers are. Here, the generated expression is used in `JoyPixels\Client::toShort()` which looks like `/.../ui` so that's what we use.

If you want to generate the same regexp for other programming languages such as JavaScript or Java, [other factories](https://github.com/s9e/RegexpBuilder#factories) are available and all it takes is to change the factory's name and set the corresponding options. Additionally, the library is [available as a command line interface tool](https://github.com/s9e/RegexpBuilderCommand).

Note that s9e/regexp-builder:2.0 requires PHP 8.1. If composer complains about being unable to find a version of PHPUnit for that version PHP, you politely ask it to ignore this requirement with `composer install --ignore-platform-reqs`
