### PR TITLE
PHP Fix shortnameToUnicode when invalid shortname

### DIFF
--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -214,7 +214,9 @@ class Client implements ClientInterface
             $unicode_replace = $ruleset->getUnicodeReplace();
             $shortname = mb_strtolower($m[1]);
 
-            return $unicode_replace[$shortname];
+            return isset($unicode_replace[$shortname])
+                ? $unicode_replace[$shortname]
+                : $m[0];
         }
     }
 

--- a/lib/php/tests/JoyPixelsTest.php
+++ b/lib/php/tests/JoyPixelsTest.php
@@ -90,6 +90,19 @@ final class JoyPixelsTest extends TestCase
     }
 
     /**
+     * entries can contain some :xxx: words which are not valid shortnames. They must not break anything
+     *
+     * @return void
+     */
+    public function testShortnameToUnicodeAcceptWrongShortname()
+    {
+        $test     = 'Hello :world:! 😄 :smile:';
+        $expected = 'Hello :world:! 😄 😄';
+
+        $this->assertEquals($expected, $this->client->shortnameToUnicode($test));
+    }
+
+    /**
      * test $this->client->shortnameToAscii()
      *
      * @return void


### PR DESCRIPTION
this fixes the 

"Undefined array key ":sometingHere:" in/src/Client.php:216