### PR TITLE
perf: cache repeat regexp processing for toShort

### DIFF
--- a/lib/js/joypixels.js
+++ b/lib/js/joypixels.js
@@ -362,11 +362,14 @@
         return str;
     };
 
+    // callback prevents replacing anything inside of these common html tags as well as between an <object></object> tag
+    var replaceWithShortnameLookup = function(entire, m1) {
+        return ((typeof m1 === 'undefined') || (m1 === '')) ? entire : ns.shortnameLookup[m1];
+    };
+
     // this is really just unicodeToShortname() but I opted for the shorthand name to match toImage()
     ns.toShort = function(str) {
-        var find = ns.unicodeCharRegex();
-        str = ns.replaceAll(str, find);
-        return  str;
+        return str.replace(unicodeCharRegexEscapedSearch(), replaceWithShortnameLookup);
     };
 
     ns.escapeHTML = function (string) {
@@ -475,13 +478,24 @@
 
     ns.replaceAll = function(string, find) {
         var escapedFind = ns.escapeRegExp(find); //sorted largest output to smallest output
-        var search = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|("+escapedFind+")", "gi");
-        // callback prevents replacing anything inside of these common html tags as well as between an <object></object> tag
-        var replace = function(entire, m1) {
-            return ((typeof m1 === 'undefined') || (m1 === '')) ? entire : ns.shortnameLookup[m1];
-        };
-        return string.replace(search, replace);
+        var search = escapeFindForSearch(escapedFind);
+        return string.replace(search, replaceWithShortnameLookup);
     };
+
+    function escapeFindForSearch(escapedFind) {
+        return new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|("+escapedFind+")", "gi");
+    }
+
+    var unicodeCharRegexEscapedSearchCached = null;
+
+    function unicodeCharRegexEscapedSearch() {
+        if (!unicodeCharRegexEscapedSearchCached) {
+            var unicodeCharRegexEscaped = ns.escapeRegExp(ns.unicodeCharRegex());
+            unicodeCharRegexEscapedSearchCached = escapeFindForSearch(unicodeCharRegexEscaped);
+        }
+
+        return unicodeCharRegexEscapedSearchCached;
+    }
 
 }(this.joypixels = this.joypixels || {}));
 if(typeof module === "object") module.exports = this.joypixels;


### PR DESCRIPTION
Caches the escaped search regex used in `ns.toShort`, under `unicodeCharRegexEscapedSearch()`. This way each call to `toShort` doesn't need to call `ns.escapeRegExp` on `ns.unicodeCharRegex()`.

Additionally extracts the replacer function used in `str.replace` to a shared one - that way it can be used in both `ns.toShort` and `ns.replaceAll`.

@marvinhagemeister is the one who first prototyped these changes; we'd paired looking at https://github.com/JoshuaKGoldberg/repros/tree/draft-js-emoji-plugin-emoji-toolkit-performance. See #58 for more context.

Fixes #58

Co-authored-by: Marvin Hagemeister <hello@marvinh.dev>